### PR TITLE
vmx requires multiple hard disks

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -43,10 +43,10 @@ type NetworkConf struct {
 }
 
 type ResourceConf struct {
-	CPU    string   `yaml:"cpu"`
-	Memory string   `yaml:"mem"`
-	Disk   DiskConf `yaml:"disk"`
-	CDROM  string   `yaml:"cdrom"`
+	CPU    string     `yaml:"cpu"`
+	Memory string     `yaml:"mem"`
+	Disks  []DiskConf `yaml:"disks"`
+	CDROM  string     `yaml:"cdrom"`
 }
 
 type DiskConf struct {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -56,8 +56,12 @@ var runCmd = &cobra.Command{
 					"-smp", node.Resources.CPU,
 					"-pidfile", fmt.Sprintf("/var/run/nlab/%v/%v.pid", cfg.Tag, node.Tag),
 					"-m", node.Resources.Memory,
-					"-drive", fmt.Sprintf("format=%v,file=%v", node.Resources.Disk.Format, node.Resources.Disk.File),
 					"-display", "none", "-serial", fmt.Sprintf("telnet::%v,nowait,server", telnetPort),
+				}
+
+				for _, disk := range node.Resources.Disks {
+					cmd := []string{"-drive", fmt.Sprintf("format=%v,file=%v", disk.Format, disk.File)}
+					qemuArgs = append(qemuArgs, cmd...)
 				}
 
 				if node.Resources.CDROM != "" {

--- a/lab.yml
+++ b/lab.yml
@@ -4,55 +4,12 @@ nodes:
         - tag: rtr1
           network:
                   management: true
-                  links:
-                        - rtr1-rtr2
-                        - rtr1-sw1
-                        - rtr1-sw2
+                  links: []
           resources:
                   cpu: 2
                   mem: 512
                   cdrom: null
-                  disk: { file: /dev/zvol/tank/vmdisks/vsrx-1, format: raw }
-        - tag: rtr2
-          network:
-                  management: true
-                  links:
-                        - rtr1-rtr2
-                        - rtr2-sw1
-                        - rtr2-sw2
-          resources:
-                  cpu: 2
-                  mem: 1024
-                  cdrom: null
-                  disk: { file: /home/daryl/vqfx10k-re.qcow, format: qcow }
-        - tag: sw1
-          network:
-                  management: true
-                  links:
-                        - rtr1-sw1
-                        - rtr2-sw2
-                        - sw1-sw2
-          resources:
-                  cpu: 1
-                  mem: 2048
-                  cdrom: null
-                  disk: { file: /dev/zvol/tank/vmdisks/nxos-1, format: raw }
-        - tag: sw2
-          network:
-                  management: true
-                  links: 
-                        - rtr1-sw2
-                        - rtr2-sw2
-                        - sw1-sw2
-          resources:
-                  cpu: 1
-                  mem: 512
-                  cdrom: null
-                  disk: { file: /dev/zvol/tank/vmdisks/vios-1, format: raw }
-links:
-        - tag: rtr1-rtr2
-        - tag: rtr1-sw1
-        - tag: rtr1-sw2
-        - tag: rtr2-sw1
-        - tag: rtr2-sw2
-        - tag: sw1-sw2
+                  disks:
+                      - { file: /dev/zvol/tank/vmdisks/vsrx-1, format: raw }
+                      - { file: /dev/zvol/tank/vmdisks/vcp-1, format: raw }
+links: []


### PR DESCRIPTION
juniper vmx control plane machine requires 3 disks so support for multiple disks is required.