### PR TITLE
Implement option of using UDP pseudo wires 

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/darylturner/nlab/internal/config"
+	"github.com/darylturner/nlab/internal/network"
 	"github.com/darylturner/nlab/internal/node"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -38,6 +39,14 @@ var runCmd = &cobra.Command{
 			panic(err)
 		}
 
+		pwMap := make(map[string]*network.PseudoWire)
+		if cfg.PseudoWire {
+			pwMap, err = network.GetPseudoWireMap(cfg)
+			if err != nil {
+				log.Fatal("error creating pseudowire map")
+			}
+		}
+
 		for _, ndConf := range cfg.Nodes {
 			if tag == ndConf.Tag || tag == "" {
 				nd, err := node.New(ndConf)
@@ -49,7 +58,7 @@ var runCmd = &cobra.Command{
 					continue
 				}
 
-				status, err := nd.Run(cfg, dryRun)
+				status, err := nd.Run(cfg, dryRun, pwMap)
 				if err != nil {
 					log.WithFields(log.Fields{
 						"tag": ndConf.Tag,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Topology struct {
 	Tag              string     `json:"tag"`
 	Nodes            []NodeConf `json:"nodes"`
 	ManagementBridge string     `json:"management_bridge"`
+	PseudoWire       bool       `json:"pseudo_wire"`
 }
 
 type NodeConf struct {

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -16,6 +16,12 @@ type Network interface {
 	AddNode(string)
 }
 
+type PseudoWire struct {
+	Type     string
+	Init     bool
+	BasePort int
+}
+
 func GetMap(cfg *config.Topology) (map[string]Network, error) {
 	allLinks := make(map[string]Network)
 	os := runtime.GOOS
@@ -39,6 +45,34 @@ func GetMap(cfg *config.Topology) (map[string]Network, error) {
 			default:
 				return allLinks, errors.New("running on unsupported os")
 			}
+		}
+	}
+
+	return allLinks, nil
+}
+
+func GetPseudoWireMap(cfg *config.Topology) (map[string]*PseudoWire, error) {
+	allLinks := make(map[string]*PseudoWire)
+	portBase := 30000
+	os := runtime.GOOS
+	for _, nd := range cfg.Nodes {
+		for _, link := range nd.Network.Links {
+			if _, ok := allLinks[link]; ok {
+				continue
+			}
+
+			switch os {
+			case "linux":
+				allLinks[link] = &PseudoWire{
+					Type:     "qemu-unicast-udp",
+					Init:     false,
+					BasePort: portBase,
+				}
+			default:
+				return allLinks, errors.New("running on unsupported os")
+			}
+
+			portBase += 2
 		}
 	}
 

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -22,28 +22,40 @@ type PseudoWire struct {
 	BasePort int
 }
 
+func newNet(link string, nd config.NodeConf, allLinks map[string]Network) error {
+	if net, ok := allLinks[link]; ok {
+		net.AddNode(nd.Tag)
+		return nil
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		net := netlinux.New(link)
+		net.AddNode(nd.Tag)
+		allLinks[link] = &net
+	default:
+		return errors.New("running on unsupported os")
+	}
+
+	return nil
+}
+
 func GetMap(cfg *config.Topology) (map[string]Network, error) {
 	allLinks := make(map[string]Network)
-	os := runtime.GOOS
 	for _, nd := range cfg.Nodes {
 		if nd.Network.Management == true {
 			link := "_" + cfg.ManagementBridge
 			nd.Network.Links = append(nd.Network.Links, link)
+			if err := newNet(link, nd, allLinks); err != nil {
+				return allLinks, err
+			}
 		}
 
-		for _, link := range nd.Network.Links {
-			if net, ok := allLinks[link]; ok {
-				net.AddNode(nd.Tag)
-				continue
-			}
-
-			switch os {
-			case "linux":
-				net := netlinux.New(link)
-				net.AddNode(nd.Tag)
-				allLinks[link] = &net
-			default:
-				return allLinks, errors.New("running on unsupported os")
+		if !cfg.PseudoWire {
+			for _, link := range nd.Network.Links {
+				if err := newNet(link, nd, allLinks); err != nil {
+					return allLinks, err
+				}
 			}
 		}
 	}

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -17,9 +17,9 @@ type Network interface {
 }
 
 type PseudoWire struct {
-	Type     string
-	Init     bool
-	BasePort int
+	Type        string
+	Initialised bool
+	Port        int
 }
 
 func newNet(link string, nd config.NodeConf, allLinks map[string]Network) error {
@@ -45,7 +45,6 @@ func GetMap(cfg *config.Topology) (map[string]Network, error) {
 	for _, nd := range cfg.Nodes {
 		if nd.Network.Management == true {
 			link := "_" + cfg.ManagementBridge
-			nd.Network.Links = append(nd.Network.Links, link)
 			if err := newNet(link, nd, allLinks); err != nil {
 				return allLinks, err
 			}
@@ -76,9 +75,9 @@ func GetPseudoWireMap(cfg *config.Topology) (map[string]*PseudoWire, error) {
 			switch os {
 			case "linux":
 				allLinks[link] = &PseudoWire{
-					Type:     "qemu-unicast-udp",
-					Init:     false,
-					BasePort: portBase,
+					Type:        "qemu-unicast-udp",
+					Initialised: false,
+					Port:        portBase,
 				}
 			default:
 				return allLinks, errors.New("running on unsupported os")

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -3,6 +3,7 @@ package node
 import (
 	"errors"
 	"github.com/darylturner/nlab/internal/config"
+	"github.com/darylturner/nlab/internal/network"
 	"github.com/darylturner/nlab/internal/node/qemu"
 	"github.com/sirupsen/logrus"
 	"runtime"
@@ -20,6 +21,6 @@ func New(cfg config.NodeConf) (Node, error) {
 }
 
 type Node interface {
-	Run(*config.Topology, bool) (logrus.Fields, error)
+	Run(*config.Topology, bool, map[string]*network.PseudoWire) (logrus.Fields, error)
 	Stop(*config.Topology) error
 }

--- a/internal/node/qemu/qemu.go
+++ b/internal/node/qemu/qemu.go
@@ -23,7 +23,7 @@ type QemuNode struct {
 	config.NodeConf
 }
 
-func (q QemuNode) Run(cfg *config.Topology, dryRun bool) (logrus.Fields, error) {
+func (q QemuNode) Run(cfg *config.Topology, dryRun bool, pwMap map[string]*network.PseudoWire) (logrus.Fields, error) {
 	var index int // need to find which node we are within the topology
 	for i, nd := range cfg.Nodes {
 		if nd.Tag == q.Tag {
@@ -57,8 +57,12 @@ func (q QemuNode) Run(cfg *config.Topology, dryRun bool) (logrus.Fields, error) 
 		qemuArgs = append(qemuArgs, linkCmd(cfg.ManagementBridge, tapName, virtIO)...)
 	}
 	for _, link := range q.Network.Links {
-		tapName := netlinux.TapUID(link, q.Tag)
-		qemuArgs = append(qemuArgs, linkCmd(link, tapName, virtIO)...)
+		if cfg.PseudoWire {
+			qemuArgs = append(qemuArgs, pwCmd(link, pwMap[link], virtIO)...)
+		} else {
+			tapName := netlinux.TapUID(link, q.Tag)
+			qemuArgs = append(qemuArgs, linkCmd(link, tapName, virtIO)...)
+		}
 	}
 
 	if !dryRun {
@@ -100,6 +104,28 @@ func (q QemuNode) Stop(cfg *config.Topology) error {
 	}
 
 	return nil
+}
+
+func pwCmd(link string, pw *network.PseudoWire, virtio bool) []string {
+	drv := "e1000"
+	if virtio {
+		drv = "virtio-net-pci"
+	}
+
+	var local, remote int
+	if pw.Init {
+		remote = pw.BasePort
+		local = pw.BasePort + 1
+	} else {
+		remote = pw.BasePort + 1
+		local = pw.BasePort
+		pw.Init = true
+	}
+
+	return []string{
+		"-device", fmt.Sprintf("%v,netdev=%s,mac=%s", drv, link, network.RandomMAC()),
+		"-netdev", fmt.Sprintf("socket,id=%s,udp=127.0.0.1:%d,localaddr=127.0.0.1:%d", link, remote, local),
+	}
 }
 
 func linkCmd(link, tap string, virtio bool) []string {

--- a/internal/node/qemu/qemu.go
+++ b/internal/node/qemu/qemu.go
@@ -31,7 +31,7 @@ func (q QemuNode) Run(cfg *config.Topology, dryRun bool, pwMap map[string]*netwo
 		}
 	}
 
-	serialPortBase := 50000 // need to make this more dynamic
+	serialPortBase := 40000 // need to make this more dynamic
 	telnetPort := serialPortBase + index
 
 	qemuArgs := []string{
@@ -113,13 +113,13 @@ func pwCmd(link string, pw *network.PseudoWire, virtio bool) []string {
 	}
 
 	var local, remote int
-	if pw.Init {
-		remote = pw.BasePort
-		local = pw.BasePort + 1
+	if pw.Initialised {
+		remote = pw.Port
+		local = pw.Port + 1
 	} else {
-		remote = pw.BasePort + 1
-		local = pw.BasePort
-		pw.Init = true
+		remote = pw.Port + 1
+		local = pw.Port
+		pw.Initialised = true
 	}
 
 	return []string{


### PR DESCRIPTION
UDP pseudo wires can now be used instead of tap/bridge for better reliability of layer 2 protocols.